### PR TITLE
Fixed grammar errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ This repository contains only java codes. There is NO executable app provided.
 
 What this app is supposed to do:
 ```java
-- Grabing data from user inputs.
-- Providing 4 activities, including car, route, transpotation and utility.
-- Providing hurdreds common car models for user to choose.
-- Allowing user to add, delete, and edit data of car, route, transpotation and utility. 
-- Automatically converting data from different acticities to a pie chart.
-- Allowing user to choose speific dates to input data.
+- Grabbing data from user inputs.
+- Providing 4 activities, including car, route, transportation and utility.
+- Providing hundreds common car models for user to choose.
+- Allowing user to add, delete, and edit data of car, route, transportation and utility. 
+- Automatically converting data from different activities to a pie chart.
+- Allowing user to choose specific dates to input data.
 - Showing total and partial calory consumption by pie chart and numbers.
-- Showing data on pie charts at specific date or a period.
+- Showing data on pie charts at a specific date or a period.
 ```
 
 Note:


### PR DESCRIPTION
"Grabing" -> "Grabbing"
"hurdreds" -> "hundreds"
"transpotation" -> "transportation"
"speific" -> "specific"
"acticities" -> "activities"
add "a" before "specific"